### PR TITLE
Add LICENSE draft based on BSCAN-5M template

### DIFF
--- a/image_preprocessing/LICENSE
+++ b/image_preprocessing/LICENSE
@@ -51,9 +51,10 @@ This repository links to forks of six other repositories, each of which are gove
 - License: Apache 2.0
 - License Link: https://github.com/IDEA-Research/MaskDINO/blob/main/LICENSE
 ### Submodule: 
-- Repository: https://github.com/Jquinto64/MaskDINO-MassID45 (forked from https://github.com/Jquinto64/MaskDINO-MassID45)
-- License: Apache 2.0
-- License Link: https://github.com/IDEA-Research/MaskDINO/blob/main/LICENSE
+### Submodule: arth-imrec
+- Repository: https://github.com/Jquinto64/arth-imrec (forked from https://github.com/jorsholm/arth-imrec)
+- License: MIT
+- License Link: https://github.com/jorsholm/arth-imrec/blob/main/LICENSE
 
 ### Submodule: 
 - Repository: https://github.com/Jquinto64/arth-imrec (forked from https://github.com/jorsholm/arth-imrec)


### PR DESCRIPTION
LICENSE file draft based on BIOSCAN-5M (https://github.com/bioscan-ml/BIOSCAN-5M/blob/main/LICENSE). The license file is placed in image_preprocessing as it represents my original code. LICENSE files of the other submodules are referenced and preserved.

TODOs:
- Add a license file to Johanna's arth-imrec repo (https://github.com/jorsholm/arth-imrec), which we use as a submodule in this repo (I suggest MIT). 