### PR TITLE
fix: correct typos and move misplaced import

### DIFF
--- a/image_preprocessing/assemble_annotations.py
+++ b/image_preprocessing/assemble_annotations.py
@@ -60,7 +60,7 @@ def update_image_paths_and_dimensions(coco_data, content_root_dir, annotation_ti
             full_image_path = os.path.join(content_root_dir, img_entry['path'])
             
             # This is required as all the toras_paths are for 'batch-1', 
-            # yet in Zenodo we place everything in an 'annotation_tiles' directoryyy
+            # yet in Zenodo we place everything in an 'annotation_tiles' directory
             if not os.path.exists(full_image_path):
                 # Try replacing 'batch-1' and 'batch-2' as per original logic
                 alt_toras_path = re.sub(r'batch-[1-3]', annotation_tiles_dir, img_entry['toras_path'])

--- a/image_preprocessing/crop_bulk_imgs.py
+++ b/image_preprocessing/crop_bulk_imgs.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import cv2
@@ -429,8 +430,6 @@ class COCODatasetCropper:
         else:
             print("\nErrors occurred during dataset cropping for one or more splits.")
         return overall_success
-
-import copy # ensure copy is imported
 
 def main(args):
     # --- Part 1: Generate Bounding Boxes (from original script's first part) ---

--- a/image_preprocessing/download_data.py
+++ b/image_preprocessing/download_data.py
@@ -33,7 +33,7 @@ def download_data(save_path):
         except requests.exceptions.RequestException as e:
             print(f"An error occurred during download: {e}")
 
-    # Clean up zip fles 
+    # Clean up zip files 
     dir_files = os.listdir(save_path)
     for item in dir_files:
         if item.endswith(".zip"):


### PR DESCRIPTION
## Summary

- Fix `directoryyy` typo in `assemble_annotations.py`
- Fix `zip fles` typo in `download_data.py`
- Move `import copy` from line 433 to top of `crop_bulk_imgs.py` with the other imports